### PR TITLE
Fix bug in yumgroup provider

### DIFF
--- a/lib/puppet/provider/yumgroup/default.rb
+++ b/lib/puppet/provider/yumgroup/default.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:yumgroup).provide(:default) do
     groups = []
 
     # get list of all groups
-    yum_content = yum('grouplist')
+    yum_content = yum('grouplist').split("\n")
 
     # turn of collecting to avoid lines like 'Loaded plugins'
     collect_groups = false


### PR DESCRIPTION
Puppet runs on v4 server were causing the following issues if `yumgroup` type was used in manifest:

```
Error: Failed to apply catalog: undefined method `each' for #<Puppet::Util::Execution::ProcessOutput:0x000000062c2b48>
```

Same error was produced if you run:

```puppet resource yumgroup```

This patch fixes the issue.