### PR TITLE
Update EPEL and IUS repos

### DIFF
--- a/manifests/repo/epel.pp
+++ b/manifests/repo/epel.pp
@@ -33,14 +33,14 @@ class yum::repo::epel (
       package { 'epel-release':
         ensure   => present,
         provider => 'rpm',
-        source   => 'http://mirror.centos.org/centos/6/extras/x86_64/Packages/epel-release-6-8.noarch.rpm',
+        source   => 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm',
       }
     }
     /^7.*/: {
       package { 'epel-release':
         ensure   => present,
         provider => 'rpm',
-        source   => 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm',
+        source   => 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',
       }
     }
   }

--- a/manifests/repo/ius.pp
+++ b/manifests/repo/ius.pp
@@ -24,25 +24,18 @@ class yum::repo::ius (
   # install package depending on major version
   case $::operatingsystemrelease {
     default: {}
-    /^5.*/: {
-      package { 'ius-release':
-        ensure   => present,
-        provider => 'rpm',
-        source   => 'http://dl.iuscommunity.org/pub/ius/stable/Redhat/5/x86_64/ius-release-1.0-15.ius.el5.noarch.rpm',
-      }
-    }
     /^6.*/: {
       package { 'ius-release':
         ensure   => present,
         provider => 'rpm',
-        source   => 'http://dl.iuscommunity.org/pub/ius/stable/Redhat/6/x86_64/ius-release-1.0-15.ius.el6.noarch.rpm',
+        source   => 'https://centos6.iuscommunity.org/ius-release.rpm',
       }
     }
     /^7.*/: {
       package { 'ius-release':
         ensure   => present,
         provider => 'rpm',
-        source   => 'https://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-15.ius.centos7.noarch.rpm',
+        source   => 'https://centos7.iuscommunity.org/ius-release.rpm',
       }
     }
   }


### PR DESCRIPTION
EPEL and IUS offer a permanent link to latest release package, which will stop breaking puppet each time release has been bumped +1.
