### PR TITLE
Update ZFS repo URI for EL7.4

### DIFF
--- a/templates/CentOS/7.4.1708/zfs.erb
+++ b/templates/CentOS/7.4.1708/zfs.erb
@@ -1,10 +1,10 @@
 [zfs]
 <% if @kmod -%>
-name=ZFS on Linux for EL7 - kmod
-baseurl=http://download.zfsonlinux.org/epel/7/kmod/$basearch/
+name=ZFS on Linux for EL7.4 - kmod
+baseurl=http://download.zfsonlinux.org/epel/7.4/kmod/$basearch/
 <% else -%>
-name=ZFS on Linux for EL7 - dkms
-baseurl=http://download.zfsonlinux.org/epel/7/$basearch/
+name=ZFS on Linux for EL7.4 - dkms
+baseurl=http://download.zfsonlinux.org/epel/7.4/$basearch/
 <% end -%>
 enabled=1
 metadata_expire=7d
@@ -19,8 +19,8 @@ includepkgs=<%= @include.to_a.join(' ') %>
 <% end -%>
 
 [zfs-source]
-name=ZFS on Linux for EL7 - Source
-baseurl=http://download.zfsonlinux.org/epel/7/SRPMS/
+name=ZFS on Linux for EL7.4 - Source
+baseurl=http://download.zfsonlinux.org/epel/7.4/SRPMS/
 <% if @source -%>
 enabled=1
 <% else -%>


### PR DESCRIPTION
ZFS has a special URI for 7.4 due to kernel incompatibilities with previous EL versions.