### PR TITLE
Add baseurls param to CentOS base and extras

### DIFF
--- a/manifests/repo/base.pp
+++ b/manifests/repo/base.pp
@@ -8,6 +8,7 @@ class yum::repo::base (
   $priority  = '1',
   $exclude   = [],
   $include   = [],
+  $baseurl   = undef,
   $debuginfo = false,
 ){
 

--- a/manifests/repo/base/extras.pp
+++ b/manifests/repo/base/extras.pp
@@ -8,6 +8,7 @@ class yum::repo::base::extras (
   $priority  = '2',
   $exclude   = [],
   $include   = [],
+  $baseurl   = undef,
   $debuginfo = false,
 ){
   require yum::repo::base

--- a/templates/CentOS/6.10/CentOS-Base.erb
+++ b/templates/CentOS/6.10/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.2/CentOS-Base.erb
+++ b/templates/CentOS/6.2/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.3/CentOS-Base.erb
+++ b/templates/CentOS/6.3/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.4/CentOS-Base.erb
+++ b/templates/CentOS/6.4/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.5/CentOS-Base.erb
+++ b/templates/CentOS/6.5/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.6/CentOS-Base.erb
+++ b/templates/CentOS/6.6/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.7/CentOS-Base.erb
+++ b/templates/CentOS/6.7/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.9/CentOS-Base.erb
+++ b/templates/CentOS/6.9/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +31,12 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/7.0.1406/CentOS-Base.erb
+++ b/templates/CentOS/7.0.1406/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.0.1406/CentOS-Extras.erb
+++ b/templates/CentOS/7.0.1406/CentOS-Extras.erb
@@ -1,8 +1,12 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.1.1503/CentOS-Base.erb
+++ b/templates/CentOS/7.1.1503/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.3.1611/CentOS-Base.erb
+++ b/templates/CentOS/7.3.1611/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.3.1611/CentOS-Extras.erb
+++ b/templates/CentOS/7.3.1611/CentOS-Extras.erb
@@ -1,8 +1,12 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.4.1708/CentOS-Base.erb
+++ b/templates/CentOS/7.4.1708/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.4.1708/CentOS-Extras.erb
+++ b/templates/CentOS/7.4.1708/CentOS-Extras.erb
@@ -1,8 +1,12 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.5.1804/CentOS-Base.erb
+++ b/templates/CentOS/7.5.1804/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.5.1804/CentOS-Extras.erb
+++ b/templates/CentOS/7.5.1804/CentOS-Extras.erb
@@ -1,8 +1,12 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.6.1810/CentOS-Base.erb
+++ b/templates/CentOS/7.6.1810/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.6.1810/CentOS-Extras.erb
+++ b/templates/CentOS/7.6.1810/CentOS-Extras.erb
@@ -1,8 +1,12 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.7.1908/CentOS-Base.erb
+++ b/templates/CentOS/7.7.1908/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.7.1908/CentOS-Extras.erb
+++ b/templates/CentOS/7.7.1908/CentOS-Extras.erb
@@ -1,8 +1,12 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.8.2003/CentOS-Base.erb
+++ b/templates/CentOS/7.8.2003/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [base]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>
@@ -27,8 +31,12 @@ includepkgs=<%= @include.join(' ') %>
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
+<% if @baseurl -%>
+baseurl=<%= @baseurl.sub('/os/','/updates/') %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/7.8.2003/CentOS-Extras.erb
+++ b/templates/CentOS/7.8.2003/CentOS-Extras.erb
@@ -1,8 +1,12 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+<% end -%>
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=<%= @priority %>

--- a/templates/CentOS/8.1.1911/CentOS-Base.erb
+++ b/templates/CentOS/8.1.1911/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [BaseOS]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/
+<% end -%>
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/templates/CentOS/8.2.2004/CentOS-Base.erb
+++ b/templates/CentOS/8.2.2004/CentOS-Base.erb
@@ -12,8 +12,12 @@
 
 [BaseOS]
 name=CentOS-$releasever - Base
+<% if @baseurl -%>
+baseurl=<%= @baseurl %>
+<% else -%>
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/
+<% end -%>
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial


### PR DESCRIPTION
Ditching mirrorlist and using custom baseurl is the only way to force yum to use internal repository mirrors.