### PR TITLE
Unified nginx repo file

### DIFF
--- a/files/CentOS/5.10/nginx.repo
+++ b/files/CentOS/5.10/nginx.repo
@@ -1,6 +1,0 @@
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/$releasever/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/5.11/nginx.repo
+++ b/files/CentOS/5.11/nginx.repo
@@ -1,6 +1,0 @@
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/$releasever/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/5.9/nginx.repo
+++ b/files/CentOS/5.9/nginx.repo
@@ -1,6 +1,0 @@
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/$releasever/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.10/nginx.repo
+++ b/files/CentOS/6.10/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.3/nginx.repo
+++ b/files/CentOS/6.3/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.4/nginx.repo
+++ b/files/CentOS/6.4/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.5/nginx.repo
+++ b/files/CentOS/6.5/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.6/nginx.repo
+++ b/files/CentOS/6.6/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.7/nginx.repo
+++ b/files/CentOS/6.7/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.8/nginx.repo
+++ b/files/CentOS/6.8/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/6.9/nginx.repo
+++ b/files/CentOS/6.9/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/6/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/7.1.1503/nginx.repo
+++ b/files/CentOS/7.1.1503/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/7.3.1611/nginx.repo
+++ b/files/CentOS/7.3.1611/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/7.4.1708/nginx.repo
+++ b/files/CentOS/7.4.1708/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/7.5.1804/nginx.repo
+++ b/files/CentOS/7.5.1804/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/7.6.1810/nginx.repo
+++ b/files/CentOS/7.6.1810/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/7.7.1908/nginx.repo
+++ b/files/CentOS/7.7.1908/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/files/CentOS/7.8.2003/nginx.repo
+++ b/files/CentOS/7.8.2003/nginx.repo
@@ -1,8 +1,0 @@
-# nginx.repo
-
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
-priority=1

--- a/manifests/repo/nginx.pp
+++ b/manifests/repo/nginx.pp
@@ -4,9 +4,10 @@
 # https://nginx.org
 #
 class yum::repo::nginx (
-  $exclude   = [],
-  $include   = [],
-  $debuginfo = false,
+  $priority = '1',
+  $exclude  = [],
+  $include  = [],
+  $mainline = false,
 ){
   require yum::repo::base
 
@@ -15,33 +16,7 @@ class yum::repo::nginx (
     mode    => '0644',
     owner   => root,
     group   => root,
-    source  => "puppet:///modules/yum/${::operatingsystem}/${::operatingsystemrelease}/nginx.repo",
-    require => Package['nginx-release-centos'],
+    content => template("yum/${::operatingsystem}/nginx.erb"),
   }
 
-  # install package depending on major version
-  case $::operatingsystemrelease {
-    default : { }
-    /^5.*/: {
-      package { 'nginx-release-centos' :
-        ensure   => present,
-        provider => 'rpm',
-        source   => 'http://nginx.org/packages/centos/5/noarch/RPMS/nginx-release-centos-5-0.el5.ngx.noarch.rpm',
-      }
-    }
-    /^6.*/: {
-      package { 'nginx-release-centos' :
-        ensure   => present,
-        provider => 'rpm',
-        source   => 'http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm',
-      }
-    }
-    /^7.*/: {
-      package { 'nginx-release-centos' :
-        ensure   => present,
-        provider => 'rpm',
-        source   => 'http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm',
-      }
-    }
-  }
 }

--- a/templates/CentOS/nginx.erb
+++ b/templates/CentOS/nginx.erb
@@ -1,0 +1,33 @@
+[nginx-stable]
+name=nginx stable repo
+baseurl=http://nginx.org/packages/centos/$releasever/$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=https://nginx.org/keys/nginx_signing.key
+module_hotfixes=true
+priority=<%= @priority %>
+<% unless @exclude.empty? -%>
+exclude=<%= @exclude.to_a.join(' ') %>
+<% end -%>
+<% unless @include.empty? -%>
+includepkgs=<%= @include.to_a.join(' ') %>
+<% end -%>
+
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=http://nginx.org/packages/mainline/centos/$releasever/$basearch/
+gpgcheck=1
+<% if @mainline -%>
+enabled = 1
+<% else -%>
+enabled = 0
+<% end -%>
+gpgkey=https://nginx.org/keys/nginx_signing.key
+module_hotfixes=true
+priority=<%= @priority %>
+<% unless @exclude.empty? -%>
+exclude=<%= @exclude.to_a.join(' ') %>
+<% end -%>
+<% unless @include.empty? -%>
+includepkgs=<%= @include.to_a.join(' ') %>
+<% end -%>


### PR DESCRIPTION
Nginx repo doesn't provide release package for CentOS 8. I created template following official instructions:
 http://nginx.org/en/linux_packages.html#RHEL-CentOS.