### PR TITLE
Point CentOS 6 yum repos to Vault URL

### DIFF
--- a/templates/CentOS/6.10/CentOS-Base.erb
+++ b/templates/CentOS/6.10/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.10/CentOS-Contrib.erb
+++ b/templates/CentOS/6.10/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.10/CentOS-Extras.erb
+++ b/templates/CentOS/6.10/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.10/CentOS-Plus.erb
+++ b/templates/CentOS/6.10/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.10/CentOS-SCLo-scl-rh.erb
+++ b/templates/CentOS/6.10/CentOS-SCLo-scl-rh.erb
@@ -1,11 +1,11 @@
 # CentOS-SCLo-rh.repo
 #
-# Please see http://wiki.centos.org/SpecialInterestGroup/SCLo for more
+# Please see https://wiki.centos.org/SpecialInterestGroup/SCLo for more
 # information
 
 [centos-sclo-rh]
 name=CentOS-6 - SCLo rh
-baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/rh/
+baseurl=https://vault.centos.org/6/sclo/$basearch/rh/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
@@ -19,7 +19,7 @@ includepkgs=<%= @include.join(' ') %>
 
 [centos-sclo-rh-testing]
 name=CentOS-6 - SCLo rh Testing
-baseurl=http://buildlogs.centos.org/centos/6/sclo/$basearch/rh/
+baseurl=https://buildlogs.centos.org/centos/6/sclo/$basearch/rh/
 gpgcheck=0
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
@@ -33,7 +33,7 @@ includepkgs=<%= @include.join(' ') %>
 
 [centos-sclo-rh-source]
 name=CentOS-6 - SCLo rh Sources
-baseurl=http://vault.centos.org/centos/6/sclo/Source/rh/
+baseurl=https://vault.centos.org/centos/6/sclo/Source/rh/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
@@ -47,7 +47,7 @@ includepkgs=<%= @include.join(' ') %>
 
 [centos-sclo-rh-debuginfo]
 name=CentOS-6 - SCLo rh Debuginfo
-baseurl=http://debuginfo.centos.org/centos/6/sclo/$basearch/
+baseurl=https://debuginfo.centos.org/centos/6/sclo/$basearch/
 gpgcheck=1
 <% if @debuginfo -%>
 enabled=1

--- a/templates/CentOS/6.10/CentOS-SCLo-scl.erb
+++ b/templates/CentOS/6.10/CentOS-SCLo-scl.erb
@@ -1,7 +1,7 @@
 [centos-sclo-sclo]
 name=CentOS-6 - SCLo sclo
-# baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/sclo/
-mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=6&repo=sclo-sclo
+# baseurl=https://vault.centos.org/6/sclo/$basearch/sclo/
+#mirrorlist=https://mirrorlist.centos.org?arch=$basearch&release=6&repo=sclo-sclo
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo

--- a/templates/CentOS/6.2/CentOS-Base.erb
+++ b/templates/CentOS/6.2/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.2/CentOS-Contrib.erb
+++ b/templates/CentOS/6.2/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.2/CentOS-Extras.erb
+++ b/templates/CentOS/6.2/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.2/CentOS-Plus.erb
+++ b/templates/CentOS/6.2/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.3/CentOS-Base.erb
+++ b/templates/CentOS/6.3/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.3/CentOS-Contrib.erb
+++ b/templates/CentOS/6.3/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.3/CentOS-Extras.erb
+++ b/templates/CentOS/6.3/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.3/CentOS-Plus.erb
+++ b/templates/CentOS/6.3/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.4/CentOS-Base.erb
+++ b/templates/CentOS/6.4/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.4/CentOS-Contrib.erb
+++ b/templates/CentOS/6.4/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.4/CentOS-Extras.erb
+++ b/templates/CentOS/6.4/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.4/CentOS-Plus.erb
+++ b/templates/CentOS/6.4/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.5/CentOS-Base.erb
+++ b/templates/CentOS/6.5/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.5/CentOS-Contrib.erb
+++ b/templates/CentOS/6.5/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.5/CentOS-Extras.erb
+++ b/templates/CentOS/6.5/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.5/CentOS-Plus.erb
+++ b/templates/CentOS/6.5/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.6/CentOS-Base.erb
+++ b/templates/CentOS/6.6/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.6/CentOS-Contrib.erb
+++ b/templates/CentOS/6.6/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.6/CentOS-Extras.erb
+++ b/templates/CentOS/6.6/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.6/CentOS-Plus.erb
+++ b/templates/CentOS/6.6/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.7/CentOS-Base.erb
+++ b/templates/CentOS/6.7/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.7/CentOS-Contrib.erb
+++ b/templates/CentOS/6.7/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.7/CentOS-Extras.erb
+++ b/templates/CentOS/6.7/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.7/CentOS-Plus.erb
+++ b/templates/CentOS/6.7/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.8/CentOS-Base.erb
+++ b/templates/CentOS/6.8/CentOS-Base.erb
@@ -12,8 +12,8 @@
 
 [base]
 name=CentOS-$releasever - Base
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -27,8 +27,8 @@ includepkgs=<%= @include.to_a.join(' ') %>
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.8/CentOS-Contrib.erb
+++ b/templates/CentOS/6.8/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.8/CentOS-Extras.erb
+++ b/templates/CentOS/6.8/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.8/CentOS-Plus.erb
+++ b/templates/CentOS/6.8/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.9/CentOS-Base.erb
+++ b/templates/CentOS/6.9/CentOS-Base.erb
@@ -15,8 +15,8 @@ name=CentOS-$releasever - Base
 <% if @baseurl -%>
 baseurl=<%= @baseurl %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/os/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>
@@ -34,8 +34,8 @@ name=CentOS-$releasever - Updates
 <% if @baseurl -%>
 baseurl=<%= @baseurl.sub('/os/','/updates/') %>
 <% else -%>
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/updates/$basearch/
 <% end -%>
 gpgcheck=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.9/CentOS-Contrib.erb
+++ b/templates/CentOS/6.9/CentOS-Contrib.erb
@@ -1,8 +1,8 @@
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
-#baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/contrib/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.9/CentOS-Extras.erb
+++ b/templates/CentOS/6.9/CentOS-Extras.erb
@@ -1,8 +1,8 @@
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/extras/$basearch/
 gpgcheck=1
 priority=<%= @priority %>
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/templates/CentOS/6.9/CentOS-Plus.erb
+++ b/templates/CentOS/6.9/CentOS-Plus.erb
@@ -1,8 +1,8 @@
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+#mirrorlist=https://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=https://vault.centos.org/$releasever.<%= @facts['os']['release']['minor'] %>/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 priority=<%= @priority %>

--- a/templates/CentOS/6.9/CentOS-SCLo-scl-rh.erb
+++ b/templates/CentOS/6.9/CentOS-SCLo-scl-rh.erb
@@ -1,11 +1,11 @@
 # CentOS-SCLo-rh.repo
 #
-# Please see http://wiki.centos.org/SpecialInterestGroup/SCLo for more
+# Please see https://wiki.centos.org/SpecialInterestGroup/SCLo for more
 # information
 
 [centos-sclo-rh]
 name=CentOS-6 - SCLo rh
-baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/rh/
+baseurl=https://vault.centos.org/6/sclo/$basearch/rh/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
@@ -19,7 +19,7 @@ includepkgs=<%= @include.join(' ') %>
 
 [centos-sclo-rh-testing]
 name=CentOS-6 - SCLo rh Testing
-baseurl=http://buildlogs.centos.org/centos/6/sclo/$basearch/rh/
+baseurl=https://buildlogs.centos.org/centos/6/sclo/$basearch/rh/
 gpgcheck=0
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
@@ -33,7 +33,7 @@ includepkgs=<%= @include.join(' ') %>
 
 [centos-sclo-rh-source]
 name=CentOS-6 - SCLo rh Sources
-baseurl=http://vault.centos.org/centos/6/sclo/Source/rh/
+baseurl=https://vault.centos.org/centos/6/sclo/Source/rh/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
@@ -47,7 +47,7 @@ includepkgs=<%= @include.join(' ') %>
 
 [centos-sclo-rh-debuginfo]
 name=CentOS-6 - SCLo rh Debuginfo
-baseurl=http://debuginfo.centos.org/centos/6/sclo/$basearch/
+baseurl=https://debuginfo.centos.org/centos/6/sclo/$basearch/
 gpgcheck=1
 <% if @debuginfo -%>
 enabled=1

--- a/templates/CentOS/6.9/CentOS-SCLo-scl.erb
+++ b/templates/CentOS/6.9/CentOS-SCLo-scl.erb
@@ -1,7 +1,7 @@
 [centos-sclo-sclo]
 name=CentOS-6 - SCLo sclo
-# baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/sclo/
-mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=6&repo=sclo-sclo
+# baseurl=https://vault.centos.org/6/sclo/$basearch/sclo/
+#mirrorlist=https://mirrorlist.centos.org?arch=$basearch&release=6&repo=sclo-sclo
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo


### PR DESCRIPTION
CentOS 6 is obsolete since Nov 30th, 2020, and mirrors have been shutdown. This will fix the remaining EL6 installs by fixing yum